### PR TITLE
chore: bump client versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   op-geth:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101500.0
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.0
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
@@ -23,7 +23,7 @@ services:
     profiles: ["geth"]
 
   op-reth:
-    image: ghcr.io/paradigmxyz/op-reth:v1.2.0
+    image: ghcr.io/paradigmxyz/op-reth:v1.2.2
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-reth.sh
@@ -45,7 +45,7 @@ services:
     profiles: ["reth"]
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.11.1
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.12.0
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh


### PR DESCRIPTION
Bumps `op-geth` to v1.101503.0, `op-reth` to v1.2.2, and `op-node` to v1.12.0.