### PR TITLE
feat: pectra mainnet and pre-isthmus updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ A simple docker compose script for launching full / archive node for World Chain
 ### World Chain Mainnet
 
 - 16GB+ RAM
-- 2 TB SSD (NVME Recommended)
+- \>4TB SSD (NVME Recommended)
 - 100mb/s+ Download
 
 ### World Chain Sepolia
 
 - 16GB+ RAM
-- 500 GB SSD (NVME Recommended)
+- 1TB SSD (NVME Recommended)
 - 100mb/s+ Download
 
 ## Installation and Configuration
@@ -85,7 +85,7 @@ Make a copy of `.env.example` named `.env`.
 cp .env.example .env
 ```
 
-Open `.env` with your editor of choice
+Open `.env` with your editor of choice.
 
 ### Mandatory configurations
 
@@ -119,10 +119,10 @@ Open `.env` with your editor of choice
 ### Start
 
 ```sh
-docker compose up -d --build
+docker compose up -d
 ```
 
-Will start the node in a detatched shell (`-d`), meaning the node will continue to run in the background. We recommended to add `--build` to make sure that latest changes are being applied.
+Will start the node in a detatched shell (`-d`), meaning the node will continue to run in the background.
 
 ### View logs
 
@@ -164,7 +164,7 @@ Pull the latest updates from GitHub, and Docker Hub and rebuild the container.
 ```sh
 git pull
 docker compose pull
-docker compose up -d --build
+docker compose up -d
 ```
 
 Will upgrade your node with minimal downtime.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   op-geth:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.1
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.4
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
@@ -23,7 +23,7 @@ services:
     profiles: ["geth"]
 
   op-reth:
-    image: ghcr.io/paradigmxyz/op-reth:v1.2.2
+    image: ghcr.io/paradigmxyz/op-reth:v1.3.12
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-reth.sh
@@ -45,7 +45,7 @@ services:
     profiles: ["reth"]
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.12.1
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.2
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh

--- a/envs/worldchain-mainnet/config/rollup.json
+++ b/envs/worldchain-mainnet/config/rollup.json
@@ -34,7 +34,7 @@
   "l1_system_config_address": "0x6ab0777fd0e609ce58f939a7f70fe41f5aa6300a",
   "protocol_versions_address": "0x0000000000000000000000000000000000000000",
   "chain_op_config": {
-    "eip1559Elasticity": 2,
+    "eip1559Elasticity": 10,
     "eip1559Denominator": 50,
     "eip1559DenominatorCanyon": 250
   }

--- a/envs/worldchain-sepolia/config/rollup.json
+++ b/envs/worldchain-sepolia/config/rollup.json
@@ -35,7 +35,7 @@
   "l1_system_config_address": "0x166f9406e79a656f12f05247fb8f5dfa6155bcbf",
   "protocol_versions_address": "0x0000000000000000000000000000000000000000",
   "chain_op_config": {
-    "eip1559Elasticity": 2,
+    "eip1559Elasticity": 10,
     "eip1559Denominator": 50,
     "eip1559DenominatorCanyon": 250
   }

--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -e
 
-if [ "$NETWORK_NAME" = "worldchain-sepolia" ]; then
-  export PECTRA_HF_ARG="--override.pectrablobschedule=1742486400"
-fi
-
 # Start op-node.
 exec op-node \
   --l1=$L1_RPC_ENDPOINT \
@@ -26,4 +22,3 @@ exec op-node \
   --p2p.useragent=worldchain \
   --rollup.load-protocol-versions=true \
   --rollup.halt=major \
-  $PECTRA_HF_ARG \


### PR DESCRIPTION
Includes updates to the latest Isthmus-ready node software versions. We don't yet have a timestamp set for Isthmus on Mainnet or Sepolia, but there are still various improvements in the latest versions.