### PR TITLE
feat: bump software versions & light housekeeping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ L1_RPC_TYPE=alchemy
 # Defaults to "snap" for full node, "full" for archive node
 GETH_SYNCMODE=
 
+# Set to "hash" to force op-geth to use --state.scheme=hash
+# Use "hash" state scheme if eth_getProof support is required
+# This value is overridden to match existing storage, changing this value requires a full re-sync
+GETH_STATE_SCHEME=path
+
 ###############################################################################
 #                                ↓ OPTIONAL ↓                                 #
 ###############################################################################

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Simple World Chain Node
 
+> Anyone running a World Chain node is encouraged to join this Telegram channel for notifications of required software updates or other relevant information: [World Chain Node Updates Telegram Channel](https://t.me/world_chain_updates)
+
 A simple docker compose script for launching full / archive node for World Chain.
 
 > Forked from [simple-optimism-node](https://github.com/smartcontracts/simple-optimism-node).

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@ A simple docker compose script for launching full / archive node for World Chain
 
 > Forked from [simple-optimism-node](https://github.com/smartcontracts/simple-optimism-node).
 
-> 🚧 Note for upgrading Full Nodes:
->
-> Full Nodes must perform an intermediate software upgrade before upgrading op-geth to v1.101500.0.
-> See the op-geth release notes here for more info: https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.8
-
 ## Recommended Hardware
 
 ### World Chain Mainnet

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A simple docker compose script for launching full / archive node for World Chain
 ### World Chain Mainnet
 
 - 16GB+ RAM
-- \>4TB SSD (NVME Recommended)
+- \>16TB SSD (NVME Required)
 - 100mb/s+ Download
 
 ### World Chain Sepolia
 
 - 16GB+ RAM
-- 1TB SSD (NVME Recommended)
+- \>1TB SSD (NVME Highly Recommended)
 - 100mb/s+ Download
 
 ## Installation and Configuration
@@ -109,6 +109,13 @@ Open `.env` with your editor of choice.
     * Unspecified - Use default snap sync for full node and full sync for archive node
     * `snap` - Snap Sync (Default)
     * `full` - Full Sync (For archive node, not recommended for full node)
+* **GETH_STATE_SCHEME** - Specify storage scheme for `op-geth`
+    * `path` - Path-based Storage Scheme (Default)
+        * PBSS is now supported for `op-geth` archive nodes as of v1.101602.0. The `eth_getProof` RPC method is not supported when using PBSS.
+    * `hash` - Hash-based storage (For archive node, not recommended for full node)
+        * Hash-based storage is only recommended when support for the `eth_getProof` RPC method is required.
+> `GETH_STATE_SCHEME` must be set upon first start of your node. Changing this value later will have no effect. Migration from hash- to path-based storage (or vice versa) is not possible, the node must be re-synced from scratch.
+
 * **PORT__[...]** - Use custom port for specified components.
 
 ## Operating the Node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   op-geth:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101602.3
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.1
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
@@ -43,7 +43,7 @@ services:
     profiles: ["reth"]
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.7
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.14.1
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     profiles: ["geth"]
 
   op-reth:
-    image: ghcr.io/paradigmxyz/op-reth:v1.3.12
+    image: ghcr.io/paradigmxyz/op-reth:v1.6.0
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-reth.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   op-geth:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101503.4
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101511.1
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
@@ -45,7 +45,7 @@ services:
     profiles: ["reth"]
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.2
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.5
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
     env_file:
-      - ./envs/${NETWORK_NAME}/execution.env
       - .env
     volumes:
       - ./envs/${NETWORK_NAME}/config:/chainconfig
@@ -38,7 +37,6 @@ services:
         - ./scripts/:/scripts
         - shared:/shared
     env_file:
-      - ./envs/${NETWORK_NAME}/execution.env
       - .env
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     profiles: ["geth"]
 
   op-reth:
-    image: ghcr.io/paradigmxyz/op-reth:v1.8.1
+    image: ghcr.io/paradigmxyz/op-reth:v1.8.2
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-reth.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   op-geth:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101511.1
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101602.3
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
@@ -22,7 +22,7 @@ services:
     profiles: ["geth"]
 
   op-reth:
-    image: ghcr.io/paradigmxyz/op-reth:v1.6.0
+    image: ghcr.io/paradigmxyz/op-reth:v1.8.1
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-reth.sh
@@ -43,7 +43,7 @@ services:
     profiles: ["reth"]
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.5
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.7
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh

--- a/envs/worldchain-mainnet/execution.env
+++ b/envs/worldchain-mainnet/execution.env
@@ -1,1 +1,0 @@
-SEQUENCER_HTTP=https://worldchain-mainnet-sequencer.g.alchemy.com

--- a/envs/worldchain-sepolia/execution.env
+++ b/envs/worldchain-sepolia/execution.env
@@ -1,1 +1,0 @@
-SEQUENCER_HTTP=https://worldchain-sepolia-sequencer.g.alchemy.com

--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -10,6 +10,14 @@ if [ -z "$GETH_SYNCMODE" ]; then
   fi
 fi
 
+# Determine history.state on GETH_NODE_TYPE
+# Only relevant when using path-based storage
+if [ "$GETH_NODE_TYPE" = "full" ] && [ "$GETH_STATE_SCHEME" != "hash" ] ; then
+  export GETH_HISTORY_STATE="90000"
+else
+  export GETH_HISTORY_STATE="0"
+fi
+
 # Start op-geth.
 exec geth \
   --datadir=/data \
@@ -30,6 +38,8 @@ exec geth \
   --metrics.influxdb.database=opgeth \
   --syncmode="$GETH_SYNCMODE" \
   --gcmode="$GETH_NODE_TYPE" \
+  --state.scheme="$GETH_STATE_SCHEME" \
+  --history.state="$GETH_HISTORY_STATE" \
   --authrpc.vhosts="*" \
   --authrpc.addr=0.0.0.0 \
   --authrpc.port=8551 \

--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -38,6 +38,4 @@ exec geth \
   --rollup.disabletxpoolgossip=true \
   --port="${PORT__EXECUTION_P2P:-30303}" \
   --discovery.port="${PORT__EXECUTION_P2P:-30303}" \
-  --db.engine=pebble \
-  --state.scheme=hash \
   --op-network="$NETWORK_NAME" \

--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -34,7 +34,6 @@ exec geth \
   --authrpc.addr=0.0.0.0 \
   --authrpc.port=8551 \
   --authrpc.jwtsecret=/shared/jwt.txt \
-  --rollup.sequencerhttp="$SEQUENCER_HTTP" \
   --rollup.disabletxpoolgossip=true \
   --port="${PORT__EXECUTION_P2P:-30303}" \
   --discovery.port="${PORT__EXECUTION_P2P:-30303}" \

--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -16,7 +16,6 @@ exec op-node \
   --metrics.addr=0.0.0.0 \
   --metrics.port=7300 \
   --p2p.listen.tcp="${PORT__CONSENSUS_P2P:-9222}" \
-  --p2p.listen.udp="${PORT__CONSENSUS_P2P:-9222}" \
   --syncmode=execution-layer \
   --network=$NETWORK_NAME \
   --p2p.useragent=worldchain \

--- a/scripts/start-op-reth.sh
+++ b/scripts/start-op-reth.sh
@@ -25,6 +25,5 @@ exec op-reth node \
   --authrpc.jwtsecret=/shared/jwt.txt \
   --metrics=0.0.0.0:6060 \
   --chain="${CHAIN_NAME}" \
-  --rollup.sequencer-http=$SEQUENCER_HTTP \
   --rollup.disable-tx-pool-gossip \
   --port="${PORT__EXECUTION_P2P:-30303}" \

--- a/scripts/start-op-reth.sh
+++ b/scripts/start-op-reth.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -eu
 
+#set chain name for op-reth config
+if [ "$NETWORK_NAME" = "worldchain-mainnet" ]; then
+  export CHAIN_NAME="worldchain"
+else
+  export CHAIN_NAME="$NETWORK_NAME"
+fi
+
 exec op-reth node \
   --datadir=/data \
   --log.stdout.format log-fmt \
@@ -18,7 +25,7 @@ exec op-reth node \
   --authrpc.port=8551 \
   --authrpc.jwtsecret=/shared/jwt.txt \
   --metrics=0.0.0.0:6060 \
-  --chain "/chainconfig/genesis.json" \
+  --chain="${CHAIN_NAME}" \
   --rollup.sequencer-http=$SEQUENCER_HTTP \
   --rollup.disable-tx-pool-gossip \
   --enable-discv5-discovery \

--- a/scripts/start-op-reth.sh
+++ b/scripts/start-op-reth.sh
@@ -10,7 +10,6 @@ fi
 
 exec op-reth node \
   --datadir=/data \
-  --log.stdout.format log-fmt \
   --ws \
   --ws.origins="*" \
   --ws.addr=0.0.0.0 \
@@ -28,5 +27,4 @@ exec op-reth node \
   --chain="${CHAIN_NAME}" \
   --rollup.sequencer-http=$SEQUENCER_HTTP \
   --rollup.disable-tx-pool-gossip \
-  --enable-discv5-discovery \
   --port="${PORT__EXECUTION_P2P:-30303}" \


### PR DESCRIPTION
Bumps `op-node`, `op-geth`, and `op-reth` to latest versions. Removes unneeded configuration flags to simplify startup scripts. Uses Superchain Registry chain configuration in `op-reth` rather than Genesis file.