### PR TITLE
feat: world chain sepolia isthmus support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   op-geth:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.1
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.2
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
@@ -43,7 +43,7 @@ services:
     profiles: ["reth"]
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.14.1
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.14.3
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh

--- a/envs/worldchain-sepolia/config/rollup.json
+++ b/envs/worldchain-sepolia/config/rollup.json
@@ -30,6 +30,7 @@
   "granite_time": 1726570800,
   "holocene_time": 1737633600,
   "pectra_blob_schedule_time": 1742486400,
+  "isthmus_time": 1761825600,
   "batch_inbox_address": "0xff00000000000000000000000000000000484752",
   "deposit_contract_address": "0xff6eba109271fe6d4237eeed4bab1dd9a77dd1a4",
   "l1_system_config_address": "0x166f9406e79a656f12f05247fb8f5dfa6155bcbf",

--- a/scripts/start-op-reth.sh
+++ b/scripts/start-op-reth.sh
@@ -5,7 +5,7 @@ set -eu
 if [ "$NETWORK_NAME" = "worldchain-mainnet" ]; then
   export CHAIN_NAME="worldchain"
 else
-  export CHAIN_NAME="$NETWORK_NAME"
+  export CHAIN_NAME="/chainconfig/genesis.json"
 fi
 
 exec op-reth node \
@@ -25,5 +25,6 @@ exec op-reth node \
   --authrpc.jwtsecret=/shared/jwt.txt \
   --metrics=0.0.0.0:6060 \
   --chain="${CHAIN_NAME}" \
+  --rollup.sequencer-http=https://${NETWORK_NAME}-sequencer.g.alchemy.com \
   --rollup.disable-tx-pool-gossip \
   --port="${PORT__EXECUTION_P2P:-30303}" \


### PR DESCRIPTION
Updates `op-geth` and `op-node` to latest versions that include World Chain Sepolia Isthmus hardfork timestamp from the Superchain Registry.

Updates `genesis.json` and `rollup.json` for World Chain Sepolia to include Isthmus timestamp.

Updates `op-reth` startup script to use `genesis.json` for chain configuration on Sepolia, as the latest version does not yet include the Isthmus timestamp.