### PR TITLE
Add sequencer HTTP endpoint to geth start script and environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ L1_BEACON_RPC_ENDPOINT=https://xxx-xxx-xxx.quiknode.pro/xxxxxxxxxx
 # Type of RPC that op-node is connected to, see README
 L1_RPC_TYPE=alchemy
 
+# HTTP endpoint of the sequencer.
+SEQUENCER_HTTP=https://worldchain-mainnet.g.alchemy.com/v2/YOUR_API_KEY
+
 # Set to "full" to force op-geth to use --syncmode=full
 # Defaults to "snap" for full node, "full" for archive node
 GETH_SYNCMODE=

--- a/scripts/start-op-geth.sh
+++ b/scripts/start-op-geth.sh
@@ -44,6 +44,7 @@ exec geth \
   --authrpc.addr=0.0.0.0 \
   --authrpc.port=8551 \
   --authrpc.jwtsecret=/shared/jwt.txt \
+  --rollup.sequencerhttp="$SEQUENCER_HTTP" \
   --rollup.disabletxpoolgossip=true \
   --port="${PORT__EXECUTION_P2P:-30303}" \
   --discovery.port="${PORT__EXECUTION_P2P:-30303}" \


### PR DESCRIPTION
- Add sequencer endpoint to geth start script
- Add SEQUENCER_HTTP definition in environment example