### PR TITLE
v2.3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   world-chain:
-    image: ghcr.io/worldcoin/world-chain:v2.2.0-1
+    image: ghcr.io/worldcoin/world-chain:v2.3.0
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-reth.sh
@@ -21,7 +21,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.18.0
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.18.2
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-node.sh

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -8,4 +8,4 @@ scrape_configs:
     - targets: ['op-node:7300']
   - job_name: 'op-reth'
     static_configs:
-    - targets: ['op-reth:6060']
+    - targets: ['world-chain:6060']


### PR DESCRIPTION
- bumps world-chain to latest
- bumps op-node to v1.18.2
- fixes prometheus config